### PR TITLE
docs: make code snippet in README.md easier to copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ hosted by [https://readthedocs.org/] at https://docs.escoria-framework.org.
 To build the documentation locally, run the following using
 [Docker](https://docker.com):
 
-    docker run -it --rm -v $(pwd):/docs --entrypoint "/bin/bash" sphinxdoc/sphinx -c "pip install sphinx_rtd_theme myst_parser && sphinx-build -a . _build"
+    ./build.sh
+
+Output will be written to the `_build/` folder. You can use
+Python to host the documentation locally:
+
+    python3 -m http.server --directory _build
 
 ## Contributors
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run -it --rm -v $(pwd):/docs \
+    --entrypoint "/bin/bash" \
+    sphinxdoc/sphinx -c "pip install sphinx_rtd_theme myst_parser && sphinx-build -a . _build"


### PR DESCRIPTION
The shell command to build the docs is quite long,
making it tricky to copy/paste when viewing the rendered
Markdown on GitHub.

This moves the command into a `build.sh` script so that:

- It is easy to copy/paste from the rendered Markdown.
- We can update `./build.sh` going forward, as needed, without
  users having to learn a new command.

Also amended the docs to include a tip for running a local
webserver, as I personally can never remember this offhand.