### PR TITLE
feat: added a note about speeches files' loop import mode

### DIFF
--- a/getting_started/dialogs.rst
+++ b/getting_started/dialogs.rst
@@ -118,6 +118,15 @@ must be the same as the key. As an example, the above `say` command would play
 the audio file "worker_hello.mp3" (or any other supported audio format file
 like "worker_hello.ogg").
 
+.. hint::
+
+    It is very important to ensure that audio speech files are imported in
+    Godot with import flag `loop` set to `false`. Otherwise, it may happen in certain conditions (such as changing the sound volume while a speech audio is being played), Escoria's speech player loops the speech even if the line was already spoken.
+
+    To ensure this, select the audio files in Godot editor's Filesystem. In
+    Import panel, untick the `loop` import parameter and click the Reimport
+    button.
+
 The audio formats that Godot supports are listed here :
 :doc:`https://docs.godotengine.org/en/stable/tutorials/assets_pipeline/importing_audio_samples.html?highlight=ogg#supported-files`
 

--- a/getting_started/dialogs.rst
+++ b/getting_started/dialogs.rst
@@ -120,11 +120,14 @@ like "worker_hello.ogg").
 
 .. hint::
 
-    It is very important to ensure that audio speech files are imported in
-    Godot with import flag `loop` set to `false`. Otherwise, it may happen in certain conditions (such as changing the sound volume while a speech audio is being played), Escoria's speech player loops the speech even if the line was already spoken.
+    It is very important to ensure that any audio speech files are imported into
+    Godot with the import flag `loop` set to `false`. If `loop` is set to `true`,
+    in certain conditions (such as changing the sound volume while a speech
+    audio file is being played), Escoria's speech player will loop the speech
+    even if the line has already been spoken.
 
-    To ensure this, select the audio files in Godot editor's Filesystem. In
-    Import panel, untick the `loop` import parameter and click the Reimport
+    To configure this, select the audio files in Godot editor's Filesystem. In the
+    Import panel, untick the `loop` import parameter and click the `Reimport`
     button.
 
 The audio formats that Godot supports are listed here :


### PR DESCRIPTION
I've been trying to fix a bug spotted by @balloonpopper that causes a speech line to be looping forever even after the line was finished. This would happen if you change the volume in the middle of the speech playback : in that case, the AudioPlayer resets the resource in its stream. If that resource was imported with `loop` flag set to `true`, then AudioPlayer's `finished` signal would not be emitted anymore.

This might be a Godot bug, or maybe we're doing something wrong. Until we get more information, we will just encourage users to ensure their speech files are imported with that flag set to false, which solves the issue. Since speech audio files are not supposed to loop, this is a good practice anyway.