### PR TITLE
Fix Getting Started documentation

### DIFF
--- a/getting_started/step_by_step/1_create_escoria_project.rst
+++ b/getting_started/step_by_step/1_create_escoria_project.rst
@@ -17,6 +17,12 @@ To make starting with Escoria as easy as possible, we provide a Godot Game
 Template along with stock user interfaces and dialog managers to get you up and
 running in no time.
 
+.. hint::
+
+    The version of Escoria in Godot's Template Libraries is out of date.
+    To make sure you have the latest version, clone the develop branch
+    of the [Escoria Demo Game](https://github.com/godot-escoria/escoria-demo-game)
+    and copy over the addons folder.
 
 Game filesystem structure
 -------------------------

--- a/getting_started/step_by_step/2_create_player_character.rst
+++ b/getting_started/step_by_step/2_create_player_character.rst
@@ -213,8 +213,8 @@ specific animations for the character for each direction angle:
 * ``Idles``: Idle animations
 * ``Speaks``: Speaking animations
 
-For each direction angle, add an ``ESCAnimationResource``. Then, click each
-``ESCAnimationResource`` and put the name of the matching animation
+For each direction angle, add an ``ESCAnimationName``. Then, click each
+``ESCAnimationName`` and put the name of the matching animation
 (with the name specified in "Adding a walkcycle" above) in the "Animation"
 field, and choose whether that animation should be played mirrored by selecting
 the "Mirrored" checkbox.

--- a/getting_started/step_by_step/3_create_room.rst
+++ b/getting_started/step_by_step/3_create_room.rst
@@ -14,7 +14,7 @@ room scene we'll now create: Let's call it "pub".
 Create a new scene and set ``ESCRoom`` as its root node. Save the scene as
 "pub.tscn".
 
-* Note that you could call the scene something other than "park.tscn" -
+* Note that you could call the scene something other than "pub.tscn" -
   "room1.tscn" for example. Make sure you name things in a way that makes sense
   to your game.
 

--- a/getting_started/step_by_step/9_continuing.rst
+++ b/getting_started/step_by_step/9_continuing.rst
@@ -6,7 +6,7 @@ Congratulations! You've built your very first game with Escoria. Well done!
 But obviously, there's a lot more to do. We recommend checking out the rest
 of the documentation. For example:
 
-* :doc:`The ESC reference </getting_started/z_esc_reference>`
+* :doc:`The ESC reference </scripting/z_esc_reference>`
 * :doc:`The Escoria settings reference </getting_started/z_escoria_settings>`
 * :doc:`A walk through Escoria's architecture </advanced/escoria_architecture>`
 * :doc:`How to create your own UI </advanced/create_ui>`


### PR DESCRIPTION
Updates some out-of-date information in the tutorial. Fixes https://github.com/godot-escoria/escoria-demo-game/issues/810 

There are still 74 errors when running doc8, all in https://github.com/godot-escoria/escoria-docs/blob/devel/scripting/z_esc_reference.rst . 