### PR TITLE
updated godot documentation urls

### DIFF
--- a/advanced/custom_esc_commands.rst
+++ b/advanced/custom_esc_commands.rst
@@ -228,5 +228,5 @@ by Escoria. The classes are usually available in the
 (e.g. ``escoria.object_manager`` to access the
 :doc:`ESCObjectManager </api/ESCObjectManager>`)
 
-.. _`GDScript`: https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html
-.. _`GDScript enum Variant.Type`: https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#enumerations
+.. _`GDScript`: https://docs.godotengine.org/en/3.5/getting_started/scripting/gdscript/gdscript_basics.html
+.. _`GDScript enum Variant.Type`: https://docs.godotengine.org/en/3.5/classes/class_@globalscope.html#enumerations

--- a/advanced/escoria_architecture.rst
+++ b/advanced/escoria_architecture.rst
@@ -145,8 +145,8 @@ event. The event is based on the ``current_action`` set in the
 ESC script has an event ``:use``, the
 :doc:`event manager <../api/ESCEventManager>` will run that specific event.
 
-.. _`concept of Godot plugins`: https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html
-.. _`main scene`: https://docs.godotengine.org/en/stable/getting_started/step_by_step/exporting.html#setting-a-main-scene
+.. _`concept of Godot plugins`: https://docs.godotengine.org/en/3.5/tutorials/plugins/editor/making_plugins.html
+.. _`main scene`: https://docs.godotengine.org/en/3.5/getting_started/step_by_step/exporting.html#setting-a-main-scene
 
 Game start sequence
 -------------------

--- a/advanced/how_to_debug.rst
+++ b/advanced/how_to_debug.rst
@@ -106,7 +106,7 @@ Manager**:
     :align: center
     :alt: Crash error: Globals Manager in inspector
 
-.. _Debugger panel documentation page: https://docs.godotengine.org/en/stable/tutorials/debug/debugger_panel.html
+.. _Debugger panel documentation page: https://docs.godotengine.org/en/3.5/tutorials/debug/debugger_panel.html
 
 Escoria game crash management
 -----------------------------

--- a/advanced/index.rst
+++ b/advanced/index.rst
@@ -17,6 +17,6 @@ features.
     * `The Godot API`_
     * `Singletons (AutoLoad)`_
 
-.. _GDScript: https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/index.html
-.. _The Godot API: https://docs.godotengine.org/en/stable/classes/index.html
-.. _Singletons (AutoLoad): https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html
+.. _GDScript: https://docs.godotengine.org/en/3.5/getting_started/scripting/gdscript/index.html
+.. _The Godot API: https://docs.godotengine.org/en/3.5/classes/index.html
+.. _Singletons (AutoLoad): https://docs.godotengine.org/en/3.5/getting_started/step_by_step/singletons_autoload.html

--- a/api/CameraPushBlockCommand.md
+++ b/api/CameraPushBlockCommand.md
@@ -28,7 +28,7 @@ Make sure the target is reachable if camera limits have been configured.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix).
 
-See https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+See https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 

--- a/api/CameraPushCommand.md
+++ b/api/CameraPushCommand.md
@@ -28,7 +28,7 @@ Make sure the target is reachable if camera limits have been configured.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix):
 
-See https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+See https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 

--- a/api/CameraShiftBlockCommand.md
+++ b/api/CameraShiftBlockCommand.md
@@ -25,7 +25,7 @@ camera limits have been configured.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix).
 
-See https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+See https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 

--- a/api/CameraShiftCommand.md
+++ b/api/CameraShiftCommand.md
@@ -22,7 +22,7 @@ current location.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix):
 
-https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 

--- a/api/ESCCamera.md
+++ b/api/ESCCamera.md
@@ -85,7 +85,7 @@ func push(p_target, p_time: float = 0, p_type: int = 0)
 Push the camera towards the target in terms of position and zoom level
 using a given transition type and time.
 See
-https://docs.godotengine.org/en/stable/classes/class_tween.html#enumerations
+https://docs.godotengine.org/en/3.5/classes/class_tween.html#enumerations
 
 #### Parameters
 - p_target: Target to push to
@@ -102,7 +102,7 @@ Shift the camera by the given vector in a given time and using a specific
 Tween transition type.
 
 See
-https://docs.godotengine.org/en/stable/classes/class_tween.html#enumerations
+https://docs.godotengine.org/en/3.5/classes/class_tween.html#enumerations
 
 #### Parameters
 - p_target: Vector to shift the camera by

--- a/api/ESCGlobalsManager.md
+++ b/api/ESCGlobalsManager.md
@@ -69,7 +69,7 @@ func filter(pattern: String) -> Dictionary
 
 Filter the globals and return all matching keys and their values as
 a dictionary
-Check out [the Godot docs](https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-match)
+Check out [the Godot docs](https://docs.godotengine.org/en/3.5/classes/class_string.html#class-string-method-match)
 for the pattern format
 
 #### Parameters
@@ -97,7 +97,7 @@ func set_global_wildcard(pattern: String, value) -> void
 ```
 
 Set all globals that match the pattern to the value
-Check out [the Godot docs](https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-match)
+Check out [the Godot docs](https://docs.godotengine.org/en/3.5/classes/class_string.html#class-string-method-match)
 for the pattern format
 
 #### Parameters

--- a/api/StopSndCommand.md
+++ b/api/StopSndCommand.md
@@ -16,7 +16,7 @@ and `_speech`, which plays non-looping voice files (default: `_music`).
 
 Each simultaneous sound (e.g. multiple game sound effects) will require its
 own bus. To create additional buses, see the Godot sound documentation :
-[Audio buses](https://docs.godotengine.org/en/stable/tutorials/audio/audio_buses.html#doc-audio-buses)
+[Audio buses](https://docs.godotengine.org/en/3.5/tutorials/audio/audio_buses.html#doc-audio-buses)
 
 **Parameters**
 

--- a/getting_started/audio.rst
+++ b/getting_started/audio.rst
@@ -57,4 +57,4 @@ Voice support
 See the :doc:`documentation about dialogs </getting_started/dialogs>` for more
 details on using voice files.
 
-.. _`officially supported by Godot`: https://docs.godotengine.org/en/stable/getting_started/workflow/assets/importing_audio_samples.html
+.. _`officially supported by Godot`: https://docs.godotengine.org/en/3.5/getting_started/workflow/assets/importing_audio_samples.html

--- a/getting_started/backgrounds.rst
+++ b/getting_started/backgrounds.rst
@@ -64,6 +64,6 @@ the scene.
 The parameter ``lightmap_modulate`` can be used to additionally tint
 the ``lightmap`` texture.
 
-.. _`ParallaxBackground`: https://docs.godotengine.org/en/stable/classes/class_parallaxbackground.html
-.. _`ParallaxLayer`: https://docs.godotengine.org/en/stable/classes/class_parallaxlayer.html
+.. _`ParallaxBackground`: https://docs.godotengine.org/en/3.5/classes/class_parallaxbackground.html
+.. _`ParallaxLayer`: https://docs.godotengine.org/en/3.5/classes/class_parallaxlayer.html
 .. _`This tutorial`: https://www.youtube.com/watch?v=f8z4x6R7OSM

--- a/getting_started/camera.rst
+++ b/getting_started/camera.rst
@@ -109,4 +109,4 @@ The transitions that are supported are the names of the values used in the
 When specifying the ``TransitionType``, leave off the ``TRANS_`` prefix for
 any such parameters.
 
-:: _`Tween type` https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+:: _`Tween type` https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations

--- a/getting_started/dialogs.rst
+++ b/getting_started/dialogs.rst
@@ -140,7 +140,7 @@ like "worker_hello.ogg").
     know what text the label refers to.
 
 The audio formats that Godot supports are listed here :
-`https://docs.godotengine.org/en/stable/tutorials/assets_pipeline/importing_audio_samples.html?highlight=ogg#supported-files`
+`https://docs.godotengine.org/en/3.5/tutorials/assets_pipeline/importing_audio_samples.html?highlight=ogg#supported-files`
 
 Escoria uses a configuration parameter to specify where in your directory
 structure to find your game's audio files. This setting can be found in
@@ -155,7 +155,7 @@ Translations
 
 The detail below is only a high-level overview of Internationalization support
 in Godot. For more information, please see Godot's translation documentation
-`https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html`
+`https://docs.godotengine.org/en/3.5/tutorials/i18n/internationalizing_games.html`
 
 Creating text translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,9 +174,9 @@ Godot's importer to import it (under
 `Project/Project Settings/Localization/Tranlations/Add`).
 
 For further details on creating and importing translations see
-`https://docs.godotengine.org/en/stable/tutorials/assets_pipeline/importing_translations.html`
+`https://docs.godotengine.org/en/3.5/tutorials/assets_pipeline/importing_translations.html`
 
-Godot's built-in translation features: `https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html`
+Godot's built-in translation features: `https://docs.godotengine.org/en/3.5/tutorials/i18n/internationalizing_games.html`
 
 Using text translations in your game
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -213,7 +213,7 @@ Using audio translations in your game
 
 The following is a high-level overview of the language remapping functionality
 provided by Godot. For more in-depth documentation, please see
-`https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html?highlight=remaps#localizing-resources`
+`https://docs.godotengine.org/en/3.5/tutorials/i18n/internationalizing_games.html?highlight=remaps#localizing-resources`
 
 Godot provides a mechanism to map files between the different languages you
 provide for your game. The mapping function can be found under

--- a/getting_started/escoria_nodes.rst
+++ b/getting_started/escoria_nodes.rst
@@ -3,7 +3,7 @@ Common Escoria Nodes
 
 To make games in Escoria it's handy to understand the relationship between
 Godot's Scenes and nodes. These are documented here
-https://docs.godotengine.org/en/stable/getting_started/step_by_step/nodes_and_scenes.html#nodes
+https://docs.godotengine.org/en/3.5/getting_started/step_by_step/nodes_and_scenes.html#nodes
 
 Every location the game character can go to in the game will be its own Godot
 scene, and each of these scenes is referred to as an Escoria `room`.

--- a/getting_started/step_by_step/2_create_player_character.rst
+++ b/getting_started/step_by_step/2_create_player_character.rst
@@ -271,5 +271,5 @@ Add a ``CollisionShape2D`` node to the ``ESCPlayer`` and use a
 This concludes creating a player character. Let's
 :doc:`create a room <3_create_room>`.
 
-.. _AnimatedSprite tutorial in the Godot docs: https://docs.godotengine.org/en/stable/tutorials/2d/2d_sprite_animation.html
+.. _AnimatedSprite tutorial in the Godot docs: https://docs.godotengine.org/en/3.5/tutorials/2d/2d_sprite_animation.html
 .. _Discord: https://discordapp.com

--- a/getting_started/step_by_step/9_continuing.rst
+++ b/getting_started/step_by_step/9_continuing.rst
@@ -28,6 +28,6 @@ Thanks for trying Escoria, and we can't wait to see what you've made with it!
 
 Your Escoria project team
 
-.. _`Exporting Godot games`: https://docs.godotengine.org/en/stable/getting_started/workflow/export/exporting_projects.html
-.. _`Complying with Godot and Escoria licenses`: https://docs.godotengine.org/en/stable/tutorials/legal/complying_with_licenses.html
+.. _`Exporting Godot games`: https://docs.godotengine.org/en/3.5/getting_started/workflow/export/exporting_projects.html
+.. _`Complying with Godot and Escoria licenses`: https://docs.godotengine.org/en/3.5/tutorials/legal/complying_with_licenses.html
 

--- a/getting_started/step_by_step/index.rst
+++ b/getting_started/step_by_step/index.rst
@@ -55,9 +55,9 @@ With that out of the way, let's get started by
 
    *
 
-.. _editor introduction: https://docs.godotengine.org/en/stable/getting_started/step_by_step/intro_to_the_editor_interface.html
-.. _nodes documentation: https://docs.godotengine.org/en/stable/getting_started/step_by_step/nodes_and_scenes.html#nodes
-.. _GDScript basics: https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html
+.. _editor introduction: https://docs.godotengine.org/en/3.5/getting_started/step_by_step/intro_to_the_editor_interface.html
+.. _nodes documentation: https://docs.godotengine.org/en/3.5/getting_started/step_by_step/nodes_and_scenes.html#nodes
+.. _GDScript basics: https://docs.godotengine.org/en/3.5/getting_started/scripting/gdscript/gdscript_basics.html
 .. _2dpixx: https://opengameart.org/users/2dpixx
 .. _`Technopeasant`: https://opengameart.org/content/cartoon-male-turn-around-and-walk-cycle-sheet
 .. _Discord: https://discordapp.com

--- a/scripting/z_esc_reference.rst
+++ b/scripting/z_esc_reference.rst
@@ -416,7 +416,7 @@ Make sure the target is reachable if camera limits have been configured.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix).
 
-See https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+See https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 
@@ -446,7 +446,7 @@ Make sure the target is reachable if camera limits have been configured.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix):
 
-See https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+See https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 
@@ -643,7 +643,7 @@ camera limits have been configured.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix).
 
-See https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+See https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 
@@ -667,7 +667,7 @@ current location.
 Supported transitions include the names of the values used
 in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix):
 
-https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
+https://docs.godotengine.org/en/3.5/classes/class_tween.html?highlight=tween#enumerations
 
 For more details see: https://docs.escoria-framework.org/camera
 
@@ -1211,7 +1211,7 @@ and ``_speech``\ , which plays non-looping voice files (default: ``_music``\ ).
 
 Each simultaneous sound (e.g. multiple game sound effects) will require its
 own bus. To create additional buses, see the Godot sound documentation :
-`Audio buses <https://docs.godotengine.org/en/stable/tutorials/audio/audio_buses.html#doc-audio-buses>`_
+`Audio buses <https://docs.godotengine.org/en/3.5/tutorials/audio/audio_buses.html#doc-audio-buses>`_
 
 **Parameters**
 


### PR DESCRIPTION
Now the `stable` branch of godot points to `4.1`.
Just updated the urls to the latest 3.x lts.

## Note:
I found some url as code and some as links. It's very handy to be able to click... not sure if it's intentional. I can unify all of them to a link if you think it's useful.
